### PR TITLE
Transformations exp coords

### DIFF
--- a/scipy/spatial/transform/_rigid_transformation.pyx
+++ b/scipy/spatial/transform/_rigid_transformation.pyx
@@ -10,7 +10,8 @@ cimport cython
 np.import_array()
 
 
-def _create_skew_matrix(vec):
+cdef _create_skew_matrix(vec):
+    """Create skew-symmetric (aka cross-product) matrix for stack of vectors."""
     result = np.zeros((len(vec), 3, 3))
     result[:, 0, 1] = -vec[:, 2]
     result[:, 0, 2] = vec[:, 1]
@@ -21,7 +22,11 @@ def _create_skew_matrix(vec):
     return result
 
 
-def _compute_se3_exp_translation_transform(rot_vec):
+cdef _compute_se3_exp_translation_transform(rot_vec):
+    """Compute transform matrix from se3 translation part to SE3 translation.
+    
+    The transform matrix depends on the rotation vector.
+    """
     angle = np.linalg.norm(rot_vec, axis=1)
     mask = angle < 1e-3
 
@@ -38,7 +43,12 @@ def _compute_se3_exp_translation_transform(rot_vec):
     return np.identity(3) + k1[:, None, None] * s + k2[:, None, None] * s @ s
 
 
-def _compute_se3_log_translation_transform(rot_vec):
+cdef _compute_se3_log_translation_transform(rot_vec):
+    """Compute transform matrix from SE3 translation to se3 translation part.
+    
+    It is inverse of `_compute_se3_exp_translation_transform` in a closed analytical
+    form.
+    """
     angle = np.linalg.norm(rot_vec, axis=1)
     mask = angle < 1e-3
 
@@ -49,7 +59,6 @@ def _compute_se3_log_translation_transform(rot_vec):
     s = _create_skew_matrix(rot_vec)
 
     return np.identity(3) - 0.5 * s + k[:, None, None] * s @ s
-
 
 
 cdef _quaternion_conjugate(quat):

--- a/scipy/spatial/transform/_rigid_transformation.pyx
+++ b/scipy/spatial/transform/_rigid_transformation.pyx
@@ -907,8 +907,9 @@ cdef class RigidTransformation:
         rot_vec = exp_coords[:, :3]
         rotations = Rotation.from_rotvec(rot_vec)
 
-        V = _compute_se3_exp_translation_transform(rot_vec)
-        translations = np.einsum('ijk,ik->ij', V, exp_coords[:, 3:])
+        translations = np.einsum('ijk,ik->ij',
+                                 _compute_se3_exp_translation_transform(rot_vec),
+                                 exp_coords[:, 3:])
 
         matrix = np.empty((len(exp_coords), 4, 4), dtype=float)
         matrix[:, :3, :3] = rotations.as_matrix()

--- a/scipy/spatial/transform/tests/test_rigid_transformation.py
+++ b/scipy/spatial/transform/tests/test_rigid_transformation.py
@@ -269,22 +269,6 @@ def test_as_exp_coords():
     assert_allclose(exp_coords[:, 3:], translation, rtol=1e-15)
 
 
-def test_exp_coords_reciprocity():
-    # arbitrary rotations
-    rng = np.random.default_rng(10)
-
-    tf = RigidTransformation.random(1000, rng=rng)
-    tf_back = RigidTransformation.from_exp_coords(tf.as_exp_coords())
-    assert_allclose(tf.as_matrix(), tf_back.as_matrix(), rtol=1e-11)
-
-    # small rotation
-    tf = RigidTransformation.from_rot_trans(
-        Rotation.from_rotvec(rng.normal(scale=1e-10, size=(1000, 3))),
-        rng.normal(scale=100.0, size=(1000, 3)))
-    tf_back = RigidTransformation.from_exp_coords(tf.as_exp_coords())
-    assert_allclose(tf.as_matrix(), tf_back.as_matrix(), rtol=1e-15)
-
-
 def test_from_dual_quat():
     # identity
     assert_allclose(
@@ -466,8 +450,9 @@ def test_as_dual_quat():
 
 def test_from_as_internal_consistency():
     atol = 1e-12
-    n = 100
-    tf0 = RigidTransformation.random(n, rng=10)
+    n = 1000
+    rng = np.random.default_rng(10)
+    tf0 = RigidTransformation.random(n, rng=rng)
 
     tf1 = RigidTransformation.from_components(*tf0.as_components())
     assert_allclose(tf0.as_matrix(), tf1.as_matrix(), atol=atol)
@@ -482,6 +467,13 @@ def test_from_as_internal_consistency():
     assert_allclose(tf0.as_matrix(), tf1.as_matrix(), atol=atol)
 
     tf1 = RigidTransformation.from_dual_quat(tf0.as_dual_quat())
+    assert_allclose(tf0.as_matrix(), tf1.as_matrix(), atol=atol)
+
+    # exp_coords small rotation
+    tf0 = RigidTransformation.from_components(
+        rng.normal(scale=1000.0, size=(1000, 3)),
+        Rotation.from_rotvec(rng.normal(scale=1e-10, size=(1000, 3))))
+    tf1 = RigidTransformation.from_exp_coords(tf0.as_exp_coords())
     assert_allclose(tf0.as_matrix(), tf1.as_matrix(), atol=atol)
 
 


### PR DESCRIPTION
I've implemented the discussed methods of computing se3 <-> SE3 transforms using Taylor expansion.

Notably I've written it as standard Python functions, not Cython optimized. As I understood this is mostly your approach to `RigidTransformation` at the moment.

You can merge as it is or wait for me to come up with some more tests maybe.